### PR TITLE
Added a (better) auto-install script for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # spicetify-marketplace
+
 Download Extensions and Themes Directly from within [Spicetify](https://github.com/khanhas/spicetify-cli). 
 
 Based on the [reddit Custom App](https://github.com/khanhas/spicetify-cli/wiki/Custom-Apps#reddit)
@@ -10,6 +11,16 @@ All extensions are from community. They might contain unwanted code. Be careful 
 This project is a work-in-progress and is not finished, polished, or guaranteed to work. Use at your own risk. 
 
 ## Install
+
+### Auto Install (Windows)
+Open Powershell and paste the following:
+
+```powershell
+Invoke-WebRequest -UseBasicParsing "https://raw.githubusercontent.com/CharlieS1103/spicetify-marketplace/master/install.ps1" | Invoke-Expression
+```
+
+### Manual Install (recommended)
+
 Copy the `spicetify-marketplace` folder into your [Spicetify](https://github.com/khanhas/spicetify-cli) custom apps directory:
 | **Platform** | **Path**                                                                              |
 |------------|-----------------------------------------------------------------------------------------|

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,41 @@
+# Modified from https://github.com/JulienMaille/dribbblish-dynamic-theme/blob/main/install.ps1
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+Write-Host "Setting up..." -ForegroundColor "Green"
+
+$checkSpice = Get-Command spicetify -ErrorAction Silent
+if ($null -eq $checkSpice) {
+  Write-Host -ForegroundColor Red "Spicetify not found. Installing that for you..."
+  Invoke-WebRequest -UseBasicParsing "https://raw.githubusercontent.com/khanhas/spicetify-cli/master/install.ps1" | Invoke-Expression
+}
+
+$sp_dir = "${HOME}\spicetify-cli\CustomApps"
+if (-not (Test-Path $sp_dir)) {
+  Write-Host "Making a CustomApps folder..." -ForegroundColor "Cyan"
+  New-Item -Path $sp_dir -ItemType Directory | Out-Null
+  Write-Done
+}
+
+$spicePath = spicetify -c | Split-Path
+$sp_dot_dir = "$spicePath\CustomApps"
+if (-not (Test-Path $sp_dot_dir)) {
+  Write-Host "Making a CustomApps folder..." -ForegroundColor "Cyan"
+  New-Item -Path $sp_dot_dir -ItemType Directory | Out-Null
+}
+
+Write-Host "Downloading..." -ForegroundColor "Green"
+Invoke-WebRequest -Uri "https://github.com/CharlieS1103/spicetify-marketplace/archive/refs/heads/main.zip" -UseBasicParsing -OutFile "${HOME}/spicetify-cli/CustomApps/spicetify-marketplace.zip"
+
+Write-Host "Unzipping and installing..." -ForegroundColor "Green"
+Expand-Archive -Path "${HOME}/spicetify-cli/CustomApps/spicetify-marketplace.zip" -DestinationPath "${HOME}/spicetify-cli/CustomApps/" -Force
+Remove-Item -Path "${HOME}/spicetify-cli/CustomApps/spicetify-marketplace.zip" -Force
+if (Test-Path -Path "${HOME}/spicetify-cli/CustomApps/spicetify-marketplace") {
+  Write-Host "spicetify-marketplace was already found! Updating..." -ForegroundColor "Cyan"
+  Remove-Item -Path "${HOME}/spicetify-cli/CustomApps/spicetify-marketplace" -Force -Recurse
+}
+Rename-Item -Path "${HOME}/spicetify-cli/CustomApps/spicetify-marketplace-main" -NewName "spicetify-marketplace" -Force
+Copy-Item -Path "${HOME}/spicetify-cli/CustomApps/spicetify-marketplace" -Destination $sp_dot_dir -Recurse -Force
+spicetify config custom_apps spicetify-marketplace
+spicetify backup apply
+
+Write-Host "Done! If nothing has happened, do spicetify apply" -ForegroundColor "Green"


### PR DESCRIPTION
Made another pull requests because of the mess I made on the other one :P

I've added a powershell script that checks if spicetify is installed or not (then installs if needed), then downloads the main branch, unzips it and places it in the correct folders. It then applies the necessary Spicetify commands and installs it. (it *should* also be able to handle updates eg: it is already installed but the script is ran again)

I also added instructions on how to use this into the README.

I have gotten a few people to test it and it seems to work now. If there are any issues with this, mention me and I will try fix any bugs I couldn't find before. I am not amazing with powershell but I gave it my best shot 😅