### PR TITLE
[Snippets] Fix playlist arrows, Fix main view width & Left aligned heart icons

### DIFF
--- a/snippets.json
+++ b/snippets.json
@@ -47,6 +47,6 @@
   {
     "title": "Left aligned heart icons",
     "description": "Moves the heart icon to the left side of the track title in track views",
-    "code": ".main-trackList-rowSectionStart { margin-left: 38px !important; } .main-addButton-button.main-trackList-rowHeartButton, .main-addButton-button.main-trackList-rowHeartButton { position: absolute !important; left: 48px !important; } .Root__nav-bar { width: calc(var(--nav-bar-width) + 150px) !important; }"
+    "code": ".main-trackList-rowSectionStart { margin-left: 38px !important; } .main-addButton-button.main-trackList-rowHeartButton, .main-addButton-button.main-trackList-rowHeartButton { position: absolute !important; left: 48px !important; }"
   }
 ]

--- a/snippets.json
+++ b/snippets.json
@@ -33,5 +33,20 @@
     "title": "Fix progress bar displacement",
     "description": "Fix the progress bar displacement when listening on different devices",
     "code": ".main-connectBar-connectBar { overflow: visible !important; --triangle-position: 147px !important; align-items: unset !important; height: 0px !important; position: absolute !important; left: 80% !important; display: flex !important; bottom: 2% !important; padding: unset !important; }"
+  },
+  {
+    "title": "Fix playlist arrows",
+    "description": "Fixes the opened and closed orientation of the playlist folder arrows",
+    "code": ".main-rootlist-expandArrow { -webkit-transform: rotate(-90deg) !important; transform: rotate(-90deg) !important; } .main-rootlist-expandArrow:hover { -webkit-transform: rotate(-90deg) !important; transform: rotate(-90deg) !important; } .qAAhQw9dXNB7DbPgDDxy { -webkit-transform: rotate(0deg) !important; transform: rotate(0deg) !important; } .qAAhQw9dXNB7DbPgDDxy:hover { -webkit-transform: rotate(0deg) !important; transform: rotate(0deg) !important; }"
+  },
+  {
+    "title": "Fix main view width",
+    "description": "Makes main view fill up all available space",
+    "code": ".contentSpacing { max-width: 100% !important; }"
+  },
+  {
+    "title": "Left aligned heart icons",
+    "description": "Moves the heart icon to the left side of the track title in track views",
+    "code": ".main-trackList-rowSectionStart { margin-left: 38px !important; } .main-addButton-button.main-trackList-rowHeartButton, .main-addButton-button.main-trackList-rowHeartButton { position: absolute !important; left: 48px !important; } .Root__nav-bar { width: calc(var(--nav-bar-width) + 150px) !important; }"
   }
 ]


### PR DESCRIPTION
- `Fix playlist arrows`, fixes the opened and closed orientation of the playlist folder arrows (as well as hover state; it made more sense to me for the icons not to rotate when hovering)
![bild](https://user-images.githubusercontent.com/5434997/154807645-43651de4-58d5-473c-b967-fdeca03a87f6.png)

- `Fix main view width`, makes main view fill up all available space. This mostly applies to larger screens and when if zoomed out. 
![bild](https://user-images.githubusercontent.com/5434997/154808110-90977b83-e684-42b9-b2ea-ca81943b10a4.png)

- `Left aligned heart icons`, moves the heart icons to the left side of the track title in track views. This applies to everywhere tracks are displayed, such as in playlists, artist pages, albums etc. 
![bild](https://user-images.githubusercontent.com/5434997/154807942-c061a549-9097-45de-a69c-6dce94be7d63.png)
![bild](https://user-images.githubusercontent.com/5434997/154807828-d4a221bc-c075-4fef-8cb4-a34ba8f7ed02.png)


